### PR TITLE
Uniquely declare fragments in `graphql` HOC

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,6 +118,7 @@
     "lodash.isequal": "^4.1.1",
     "lodash.isobject": "^3.0.2",
     "lodash.pick": "^4.4.0",
+    "lodash.uniq": "^4.5.0",
     "object-assign": "^4.0.1"
   }
 }

--- a/src/graphql.tsx
+++ b/src/graphql.tsx
@@ -7,6 +7,7 @@ import {
 // modules don't export ES6 modules
 import pick = require('lodash.pick');
 import flatten = require('lodash.flatten');
+import uniq = require('lodash.uniq');
 import shallowEqual from './shallowEqual';
 
 import invariant = require('invariant');
@@ -164,7 +165,7 @@ export default function graphql(
       if (newOpts) opts = assign({}, opts, newOpts);
 
       if (opts.fragments) {
-        opts.fragments = flatten(opts.fragments);
+        opts.fragments = uniq(flatten(opts.fragments));
       }
 
       if (opts.variables || !operation.variables.length) return opts;

--- a/test/react-web/client/graphql/fragments.test.tsx
+++ b/test/react-web/client/graphql/fragments.test.tsx
@@ -207,5 +207,42 @@ describe('fragments', () => {
     renderer.create(<ApolloProvider client={client}><Container /></ApolloProvider>);
   });
 
+  it('uniquely declares passed fragments in an array', (done) => {
+    const query = gql`
+      query ships { allShips(first: 1) { __typename ...Ships } }
+    `;
+    const shipFragment = createFragment(gql`
+      fragment Ships on ShipsConnection { starships { name } }
+    `);
+
+    const mockedQuery = gql`
+      query ships { allShips(first: 1) { __typename ...Ships } }
+      fragment Ships on ShipsConnection { starships { name } }
+    `;
+
+    const data = {
+      allShips: { __typename: 'ShipsConnection', starships: [ { name: 'CR90 corvette' } ] },
+    };
+    const networkInterface = mockNetworkInterface(
+      { request: { query: mockedQuery }, result: { data } }
+    );
+    const client = new ApolloClient({ networkInterface, addTypename: false });
+
+    @graphql(query, {
+      options: () => ({ fragments: [shipFragment, shipFragment]}),
+    })
+    class Container extends React.Component<any, any> {
+      componentWillReceiveProps(props) {
+        expect(props.data.loading).toBe(false);
+        expect(props.data.allShips).toEqual(data.allShips);
+        done();
+      }
+      render() {
+        return null;
+      }
+    };
+
+    renderer.create(<ApolloProvider client={client}><Container /></ApolloProvider>);
+  });
 
 });


### PR DESCRIPTION
- [ ] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass
- [ ] ~~Update CHANGELOG.md with your change~~
- [ ] ~~If this was a change that affects the external API, update the docs and post a link to the PR in the discussion~~

There occurs a particular situation where the fragment array passed to the `graphql` HOC contains multiple declarations of the same fragment instance (read: the _exact_ same fragment). This occurs when two sibling nodes declare a dependendence on the same fragment (thus the multiple declarations). However, it doesn't make sense to guard for this at `createFragment` time because these sibling nodes don't know whether or not this fragment has been registered.

Here in the `graphql` HOC, when we're flattening this tree of fragments, we want to remove those duplicate occurrences because otherwise the HOC will send an invalid query to the server containing multiple fragments with the same name. We're protected from duplicate fragment names in [createFragment](https://github.com/apollostack/apollo-client/blob/8030a2f/src/fragments.ts#L39-L43)